### PR TITLE
Session data

### DIFF
--- a/src/middlewares/getCommunity.js
+++ b/src/middlewares/getCommunity.js
@@ -1,0 +1,14 @@
+/*
+  Watch if community id is setted in the context auth data ("session"),
+  and search the object
+*/
+async function getCommunity(ctx, next) {
+  if (ctx.state.authData.communityId) {
+    ctx.state.authData.community = await ctx.orm.Community.findById(
+      ctx.state.authData.communityId
+    )
+  }
+  return next()
+}
+
+module.exports = getCommunity

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,19 +7,22 @@ router.post("auth", "/", async ctx => {
   const { email, password } = ctx.request.body
   const user = await ctx.orm.user.find({ where: { email } })
   if (user && (await user.checkPassword(password))) {
+    const voluntaries = await user.getVoluntaries()
+    const voluntary = voluntaries[0]
     const token = await new Promise((resolve, reject) => {
       jwtgenerator.sign(
         {
           id: user.id,
           email: user.email,
+          isAdmin: user.isAdmin,
+          name: user.name,
+          communityId: voluntary ? voluntary.communityId : undefined,
         },
         process.env.JWT_SECRET || "thisissosecret",
         (err, tokenResult) => (err ? reject(err) : resolve(tokenResult))
       )
     })
-    const voluntaries = await user.getVoluntaries()
-    const voluntary = voluntaries[0]
-    ctx.body = { token, user, voluntary }
+    ctx.body = { token }
   } else {
     ctx.throw(401, "Wrong e-mail or password")
   }

--- a/src/routes/event.js
+++ b/src/routes/event.js
@@ -1,37 +1,10 @@
 const KoaRouter = require("koa-router")
 const auth = require("../middlewares/authentication")
+const getCommunity = require("../middlewares/getCommunity")
 
 const router = new KoaRouter()
 
 router.use(auth)
-router.post("event", "/", async ctx => {
-  const voluntaries = await ctx.state.currentUser.getVoluntaries()
-  const voluntary = voluntaries[0]
-  const community = await voluntary.getCommunity()
-  const { description, name, start } = ctx.request.body
-  const ev = await ctx.orm.Event.build({
-    name,
-    description,
-    start: new Date(start),
-    communityId: community.id,
-  }).save()
-  ctx.response.status = 201
-  ctx.body = ev
-})
-
-router.get("event", "/", async ctx => {
-  const voluntaries = await ctx.state.currentUser.getVoluntaries()
-  const voluntary = voluntaries[0]
-  if (voluntary) {
-    const community = await voluntary.getCommunity()
-    let events = await community.getEvents()
-    ctx.response.status = 200
-    ctx.body = { events }
-  } else {
-    ctx.body = "user has no associated voluntary"
-    ctx.status = 422
-  }
-})
 
 router.get("event", "/all", async ctx => {
   if (ctx.state.currentUser.isAdmin) {
@@ -45,9 +18,45 @@ router.get("event", "/all", async ctx => {
 })
 
 router.get("event", "/date/:date", async ctx => {
-  const events = await ctx.orm.Event.findAll({ where: { start: { $between: [new Date(ctx.params.date), new Date(`${ctx.params.date}T23:59:59.99`)] } } })
+  const events = await ctx.orm.Event.findAll({
+    where: {
+      start: {
+        $between: [
+          new Date(ctx.params.date),
+          new Date(`${ctx.params.date}T23:59:59.99`)
+        ],
+      },
+    },
+  })
   ctx.response.status = 200
   ctx.body = { events }
+})
+
+/* after using getCommunity, if user has community, it will be in ctx.state.authData.community */
+router.use(getCommunity)
+router.post("event", "/", async ctx => {
+  const community = ctx.state.authData.community
+  const { description, name, start } = ctx.request.body
+  const ev = await ctx.orm.Event.build({
+    name,
+    description,
+    start: new Date(start),
+    communityId: community.id,
+  }).save()
+  ctx.response.status = 201
+  ctx.body = ev
+})
+
+router.get("event", "/", async ctx => {
+  const community = ctx.state.authData.community
+  if (community) {
+    let events = await community.getEvents()
+    ctx.response.status = 200
+    ctx.body = { events }
+  } else {
+    ctx.body = "user has no community"
+    ctx.status = 422
+  }
 })
 
 module.exports = router


### PR DESCRIPTION
- Encoding more info in JWT payload and only sending token in body. This is for simplier use receiving the login data in the App (good practice, all session data in the JWT)
- Created a Middleware to obtain the community. This use the session data communityId. After using the middleware, in the state ```ctx.state.authData.community``` will be the community object or undefined if doesnt exist